### PR TITLE
Update readme to make js controller identifier identical to ruby one  

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ context.keys().forEach((path) => {
   //   nav/user_info/index.js -> nav--user-info
   const identifier = path.replace(/^\.\//, '')
     .replace(/\/index\.js$/, '')
-    .replace(/\//, '--');
+    .replaceAll('/', '--');
 
   application.register(identifier, mod.Controller);
 });


### PR DESCRIPTION
Hi @palkan 

Js replace method replaces only the first occurrence. In order to reflect the definition in ruby code we need to use replaceAll. 

Cheers