### PR TITLE
Use global matching in identifier replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ context.keys().forEach((path) => {
   //   nav/user_info/index.js -> nav--user-info
   const identifier = path.replace(/^\.\//, '')
     .replace(/\/index\.js$/, '')
-    .replaceAll('/', '--');
+    .replace(/\//g, '--');
 
   application.register(identifier, mod.Controller);
 });

--- a/app/templates/install/index.stimulus.js
+++ b/app/templates/install/index.stimulus.js
@@ -14,7 +14,7 @@ context.keys().forEach((path) => {
   //   nav/user_info/index.js -> nav--user-info
   const identifier = path.replace(/^\\.\\//, '')
     .replace(/\\/index\\.js$/, '')
-    .replace(/\//g, '--');
+    .replace(/\\//g, '--');
 
   application.register(identifier, mod.Controller);
 });

--- a/app/templates/install/index.stimulus.js
+++ b/app/templates/install/index.stimulus.js
@@ -14,7 +14,7 @@ context.keys().forEach((path) => {
   //   nav/user_info/index.js -> nav--user-info
   const identifier = path.replace(/^\\.\\//, '')
     .replace(/\\/index\\.js$/, '')
-    .replace(/\\//, '--');
+    .replace(/\//g, '--');
 
   application.register(identifier, mod.Controller);
 });

--- a/app/templates/install/postcss-modules.js
+++ b/app/templates/install/postcss-modules.js
@@ -4,7 +4,7 @@
       if (!matches) return name;
 
       // identifier here is the same identifier we used for Stimulus controller (see above)
-      const identifier = matches[1].replace(/\//g, "--");
+      const identifier = matches[1].replace(/\\//g, "--");
 
       // We also add the `c-` prefix to all components classes
       return `c-${identifier}-${name}`;

--- a/app/templates/install/postcss-modules.js
+++ b/app/templates/install/postcss-modules.js
@@ -4,7 +4,7 @@
       if (!matches) return name;
 
       // identifier here is the same identifier we used for Stimulus controller (see above)
-      const identifier = matches[1].replace("/", "--");
+      const identifier = matches[1].replace(/\//g, "--");
 
       // We also add the `c-` prefix to all components classes
       return `c-${identifier}-${name}`;


### PR DESCRIPTION
## What is the purpose of this pull request?

Keep Node < `15.0.0` compatibility. See https://github.com/palkan/view_component-contrib/pull/6#issuecomment-958949637

## Is there anything you'd like reviewers to focus on?

I changed all 3 occurences of the `replace` method, but I'm not sure all 3 are relevant.