### PR TITLE
Allow overriding default preview template path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix configurable default template.
+
 ## 0.1.0 (2021-04-07)
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -98,10 +98,23 @@ We provide a `ViewComponentContrib::Preview` class, which helps to reduce the bo
 
 The default template shipped with the gem is as follows:
 
-```html
+```erb
 <div class="<%= container_class %>">
-  <%= render component %>
+  <%- if component -%>
+    <%= render component %>
+  <%- else -%>
+    Failed to infer a component from the preview: <%= error %>
+  <%- end -%>
 </div>
+```
+
+To define your own default template:
+```ruby
+class ApplicationViewComponentPreview < ViewComponentContrib::Preview::Base
+  # ...
+  self.default_preview_template = "path/to/your/template.html.{erb,haml,slim}"  
+  # ...
+end
 ```
 
 Let's assume that you have the following `ApplicationViewComponentPreview`:

--- a/lib/view_component_contrib/preview/default_template.rb
+++ b/lib/view_component_contrib/preview/default_template.rb
@@ -30,7 +30,7 @@ module ViewComponentContrib
             Dir.glob(File.join(path, preview_name, "preview.html.*")).any?
           end
 
-          has_preview_template ? File.join(preview_name, "preview") : DEFAULT_TEMPLATE
+          has_preview_template ? File.join(preview_name, "preview") : default_preview_template
         end
       end
     end


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixes #11 

## What changes did you make? (overview)
When a preview doesn't have a template defined use the `default_preview_template` method rather than the constant. This sure looks like it was your original intent, just a lil goof at one point.

## Is there anything you'd like reviewers to focus on?
Nah

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation

I'mma be honest I don't even know how I'd go about writing a test for this.