### PR TITLE
Detect Webpack for Rails 7 installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unpublished changes
+
+- Detect Webpack when using Rails 7 + jsbundling-rails. ([@unikitty37][])
+
 ## master
 
 - Automatic publish to RailsBytes in CI. ([@fargelus][])

--- a/app/templates/install/template.rb
+++ b/app/templates/install/template.rb
@@ -65,7 +65,7 @@ end
 
 say_status :info, "✅ RSpec configured"
 
-USE_WEBPACK = File.directory?("config/webpack")
+USE_WEBPACK = File.directory?("config/webpack") || File.file?("webpack.config.js")
 
 if USE_WEBPACK
   USE_STIMULUS = yes? "Do you use StimulusJS?"


### PR DESCRIPTION
## What is the purpose of this pull request?

Improve Webpack detection.

Rails 7 replaces the `webpacker` gem with `jsbundling-rails`, so the `config/webpack` folder is not created; instead, it puts `webpack.config.js` in the project root.

## What changes did you make? (overview)

Changed the `USE_WEBPACK` definition to check if either is present.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [X] I've added a Changelog entry
- [ ] I've updated a documentation
