### PR TITLE
feat: Example specific preview templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,7 @@ class Banner::Preview < ApplicationViewComponentPreview
 end
 ```
 
-If you need more control over your template, you can add a custom `preview.html.erb` file.
-**NOTE:** We assume that all examples uses the same `preview.html`. If it's not the case,
-you can use the original `#render_with_template` method.
+If you need more control over your template, you can add a custom `preview.html.*` template (which will be used for all examples in this preview), or even create an example-specific `previews/example.html.*` (e.g. `previews/mobile.html.erb`).
 
 ## Organizing assets (JS, CSS)
 

--- a/lib/view_component_contrib/preview/default_template.rb
+++ b/lib/view_component_contrib/preview/default_template.rb
@@ -23,14 +23,22 @@ module ViewComponentContrib
             end
         end
 
-        def preview_example_template_path(...)
+        def preview_example_template_path(example)
           super
         rescue ViewComponent::PreviewTemplateError
-          has_preview_template = preview_paths.find do |path|
+          has_example_preview = preview_paths.find do |path|
+            Dir.glob(File.join(path, preview_name, "previews", "#{example}.html.*")).any?
+          end
+
+          return File.join(preview_name, "previews", example) if has_example_preview
+
+          has_root_preview = preview_paths.find do |path|
             Dir.glob(File.join(path, preview_name, "preview.html.*")).any?
           end
 
-          has_preview_template ? File.join(preview_name, "preview") : default_preview_template
+          return File.join(preview_name, "preview") if has_root_preview
+
+          default_preview_template
         end
       end
     end

--- a/test/cases/previews_test.rb
+++ b/test/cases/previews_test.rb
@@ -42,9 +42,15 @@ class PreviewsIntegrationTest < ActionDispatch::IntegrationTest
     assert_select "div.w-full", text: "Wide"
   end
 
-  def test_preview_with_explicit_template
+  def test_preview_with_explicit_root_template
     get "/rails/view_components/custom_banner/default"
 
     assert_select "div", text: "Custom banner"
+  end
+
+  def test_preview_with_explicit_example_template
+    get "/rails/view_components/custom_banner/example"
+
+    assert_select "div", text: "Example banner"
   end
 end

--- a/test/internal/app/frontend/components/custom_banner/preview.rb
+++ b/test/internal/app/frontend/components/custom_banner/preview.rb
@@ -3,4 +3,7 @@
 class CustomBanner::Preview < ApplicationViewComponentPreview
   def default
   end
+
+  def example
+  end
 end

--- a/test/internal/app/frontend/components/custom_banner/previews/example.html.erb
+++ b/test/internal/app/frontend/components/custom_banner/previews/example.html.erb
@@ -1,0 +1,1 @@
+<%= render CustomBanner::Component.new(text: "Example banner") %>


### PR DESCRIPTION
## What is the purpose of this pull request?

Add ability to create a separate preview template per example (e.g. `my_component/previews/example.html.erb`).

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
