### PR TITLE
feat: Do not load Previews when the feature is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Detect Webpack when using Rails 7 + jsbundling-rails. ([@unikitty37][])
 
+- Skip autoloading of Preview files when viewing previews is disabled. ([@dhnaranjo][])
+
 ## master
 
 - Automatic publish to RailsBytes in CI. ([@fargelus][])
@@ -20,3 +22,4 @@
 
 [@palkan]: https://github.com/palkan
 [@fargelus]: https://github.com/fargelus
+[@dhnaranjo]: https://github.com/dhnaranjo

--- a/lib/view_component_contrib/railtie.rb
+++ b/lib/view_component_contrib/railtie.rb
@@ -3,5 +3,14 @@
 module ViewComponentContrib
   class Railtie < Rails::Railtie
     config.view_component.preview_paths << File.join(ViewComponentContrib::APP_PATH, "views")
+
+    initializer "view_component-contrib.skip_loading_previews_if_disabled" do
+      unless Rails.application.config.view_component.show_previews
+        previews = Rails.application.config.view_component.preview_paths.flat_map do |path|
+          Pathname(path).glob("**/*preview.rb")
+        end
+        Rails.autoloaders.each { |autoloader| autoloader.ignore(previews) }
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is the purpose of this pull request?

Avoid loading, for example, test-only gems in production when using sidecar previews. As discussed https://github.com/palkan/view_component-contrib/discussions/24

## What changes did you make? (overview)
Added initializer that excludes all files ending in `preview.rb` in any preview path.

## Is there anything you'd like reviewers to focus on?
Nah

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
