### PR TITLE
fix: missing newline before require

### DIFF
--- a/app/templates/install/template.rb
+++ b/app/templates/install/template.rb
@@ -3,7 +3,7 @@ say "👋 Welcome to interactive ViewComponent installer and configurator. " \
 
 run "bundle add view_component view_component-contrib --skip-install"
 
-inject_into_file "config/application.rb", "require \"view_component/engine\"\n", before: "\nBundler.require(*Rails.groups)"
+inject_into_file "config/application.rb", "\nrequire \"view_component/engine\"\n", before: "\nBundler.require(*Rails.groups)"
 
 say_status :info, "✅ ViewComponent gems added"
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixes missing newline before require in `application.rb` when running the install template.

`application.rb` before fix:
```
# you've limited to :test, :development, or :production.require "view_component/engine"

Bundler.require(*Rails.groups)
```

After fix: 
```
# you've limited to :test, :development, or :production.
require "view_component/engine"

Bundler.require(*Rails.groups)
```
