### PR TITLE
Remove deprecated rendered_component

### DIFF
--- a/templates/install/generator.rb
+++ b/templates/install/generator.rb
@@ -212,7 +212,7 @@ import "./index.css"
     let(:options) { {} }
     let(:component) { <%%= class_name %>::Component.new(**options) }
 
-    subject { rendered_component }
+    subject { rendered_content }
 
     it "renders" do
       render_inline(component)


### PR DESCRIPTION
## What is the purpose of this pull request?

Support ViewComponent v3.0.0
https://viewcomponent.org/CHANGELOG.html

## What changes did you make? 

Remove deprecated `rendered_component` in favor of `rendered_content`