### PR TITLE
Add exta style variants inheritance test

### DIFF
--- a/test/cases/style_variants_test.rb
+++ b/test/cases/style_variants_test.rb
@@ -81,6 +81,14 @@ class StyledComponentTest < ViewTestCase
       }
     end
 
+    style :component do
+      variants {
+        size {
+          lg { %w[text-larger] }
+        }
+      }
+    end
+
     attr_reader :mode
 
     def initialize(mode: :light, **parent_opts)
@@ -94,7 +102,12 @@ class StyledComponentTest < ViewTestCase
 
     render_inline(component)
 
-    assert_css "div.secondary-color.secondary-bg.text-lg"
+    # this fails, the SubComponent lost all variants when it tried to only overwrite the size variant
+    assert_css "div.secondary-color.secondary-bg.text-larger"
+    assert_no_css "div.secondary-color.secondary-bg.text-larger"
+
+    # this on the other hand passes
+    assert_css "div.text-larger"
 
     assert_css "a.text-white"
 

--- a/test/cases/style_variants_test.rb
+++ b/test/cases/style_variants_test.rb
@@ -105,7 +105,7 @@ class StyledComponentTest < ViewTestCase
     assert_css "a.text-black"
   end
 
-  class PostProccesedComponent < Component
+  class PostProcessedComponent < Component
     style_config.postprocess_with do |compiled|
       compiled.join(" ").gsub("primary", "karamba")
     end
@@ -116,7 +116,7 @@ class StyledComponentTest < ViewTestCase
   end
 
   def test_postprocessor
-    component = PostProccesedComponent.new
+    component = PostProcessedComponent.new
 
     render_inline(component)
 


### PR DESCRIPTION
This test shows that all variants are lost when a subcomponent tries to overwrite a single variant
