### PR TITLE
feat: Add inheritance strategies to style variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.2.4 (2024-12-24)
+
+- Add inheritance strategies to style variants ([@omarluq][])
+
 ## 0.2.3 (2024-07-31)
 
 - Fix publishing transpiled files (and bring Ruby 2.7 support back) ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -292,6 +292,69 @@ class ButtonComponent < ViewComponent::Base
 end
 ```
 
+### Style variants inheritance
+
+Style variants support three inheritance strategies when extending components:
+
+1. `override` (default behavior): Completely replaces parent variants.
+2. `merge` (deep merge): Preserves all variant keys unless explicitly overwritten.
+3. `extend` (shallow merge): Preserves variants unless explicitly overwritten.
+
+Consider an example:
+
+```ruby
+class Parent::Component < ViewComponent::Base
+  include ViewComponentContrib::StyleVariants
+
+  style do
+    variants do
+      size {
+        md { 'text-md' }
+        lg { 'text-lg' }
+      }
+      disabled {
+        yes { "opacity-50" }
+      }
+    end
+  end
+end
+
+# Using override strategy (default)
+class Child::Component < Parent::Component
+  style do
+    variants do
+      size {
+        lg { 'text-larger' }
+      }
+    end
+  end
+end
+
+# Using merge strategy
+class Child::Component < Parent::Component
+  style do
+    variants(strategy: :merge) do
+      size {
+        lg { 'text-larger' }
+      }
+    end
+  end
+end
+
+# Using extend strategy
+class Child::Component < Parent::Component
+  style do
+    variants(strategy: :extend) do
+      size {
+        lg { 'text-larger' }
+      }
+    end
+  end
+end
+```
+
+In this example, the `override` strategy will only keep the `size.lg` variant, dropping all others. The `merge` strategy preserves all variants and their keys, only replacing the `size.lg` value. The `extend` strategy keeps all variants but replaces all keys of the overwritten `size` variant.
+
 ### Dependent (or compound) styles
 
 Sometimes it might be necessary to define complex styling rules, e.g., when a combination of variants requires adding additional styles. That's where usage of Ruby blocks for configuration becomes useful. For example:


### PR DESCRIPTION
## What is the purpose of this pull request?

resolves https://github.com/palkan/view_component-contrib/issues/48 & https://github.com/palkan/view_component-contrib/pull/49

Adds 3 inheritance strategies to style variants:

1. override (current behavior): Completely replaces parent variants.
```ruby
class Parent::Component < Component
  style do
    variants do
      size {
        md { 'text-md' }
        lg { 'text-lg' }
      }
      disabled {
        yes { "opacity-50" }
      }
    end
  end
end

class Child::Component < Parent::Component
  style do
    variants do
      size {
        lg { 'text-larger' }
      }
    end
  end
end
```
Component only retains the size variant with lg option

2. merge (deep merge): Preserves all variant keys unless explicitly overwritten.
```ruby
class Parent::Component < Component
  style do
    variants do
      size {
        md { 'text-md' }
        lg { 'text-lg' }
      }
      disabled {
        yes { "opacity-50" }
      }
    end
  end
end

class Child::Component < Parent::Component
  style do
    variants(strategy: :merge) do
      size {
        lg { 'text-larger' }
      }
    end
  end
end
```
Maintains access to all variants and keys, with lg key overwritten.

3. extend (shallow merge): Preserves variants unless explicitly overwritten.
```ruby
class Parent::Component < Component
  style do
    variants do
      size {
        md { 'text-md' }
        lg { 'text-lg' }
      }
      disabled {
        yes { "opacity-50" }
      }
    end
  end
end

class Child::Component < Parent::Component
  style do
    variants(strategy: :extend) do
      size {
        lg { 'text-larger' }
      }
    end
  end
end
```
Maintains all variants but size variant only retains lg key.

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
