### PR TITLE
`class:` is now a special variant and will append to the resolved styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+- Add special `class:` variant to `style` helper. For appending classes.
+  Inspired by https://cva.style/docs/getting-started/extending-components
+
 ## 0.2.3 (2024-07-31)
 
 - Fix publishing transpiled files (and bring Ruby 2.7 support back) ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -277,6 +277,15 @@ And in the template:
 </div>
 ```
 
+You can also add additional classes through thr `style` method using the special `class:` variant, like so:
+
+```erb
+<div>
+  <button class="<%= style(size:, theme:, class: 'extra-class') %>">Click me</button>
+  <img src="..." class="<%= style(:image, orient: :portrait) %>">
+</div>
+```
+
 Finally, you can inject into the class list compilation process to add your own logic:
 
 ```ruby

--- a/lib/view_component_contrib/style_variants.rb
+++ b/lib/view_component_contrib/style_variants.rb
@@ -115,6 +115,8 @@ module ViewComponentContrib
           acc.concat(Array(styles))
         end
 
+        acc.concat(Array(config[:class]))
+        acc.concat(Array(config[:class_name]))
         acc
       end
 

--- a/test/cases/style_variants_test.rb
+++ b/test/cases/style_variants_test.rb
@@ -207,4 +207,21 @@ class StyledComponentTest < ViewTestCase
 
     assert_css "div.secondary-color.secondary-bg.text-md.underline"
   end
+
+  class AdditionalClassesComponent < Component
+    erb_template <<~ERB
+      <div class="<%= style(class: 'bg-blue-500') %>">Hello</div>
+    ERB
+
+    style do
+    end
+  end
+
+  def test_additional_classes
+    component = AdditionalClassesComponent.new
+
+    render_inline(component)
+
+    assert_css "div.bg-blue-500"
+  end
 end


### PR DESCRIPTION
## What is the purpose of this pull request?

Add a special `class:` variant (also `class_name:` works) to the compilation of styles which will be appended.

Fixes #51 

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
