### PR TITLE
Feature: Add `ShowIfWrapperComponent` to support wrappers conditional on multiple components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `ShowIfWrapperComponent` for wrappers that are conditional on multiple child components
+
 ## 0.2.4 (2025-01-03)
 
 - Add inheritance strategies to style variants ([@omarluq][])

--- a/README.md
+++ b/README.md
@@ -761,6 +761,8 @@ You can add this to following line to your component generator (unless it's alre
 
 ## Wrapped components
 
+### Wrapping a single component
+
 Sometimes we need to wrap a component into a custom HTML container (for positioning or whatever). By default, such wrapping doesn't play well with the `#render?` method because if we don't need a component, we don't need a wrapper.
 
 To solve this problem, we introduce a special `ViewComponentContrib::WrapperComponent` class: it takes any component as the only argument and accepts a block during rendering to define a wrapping HTML. And it renders only if the _inner component_'s `#render?` method returns true.
@@ -793,7 +795,45 @@ And the template looks like this now:
 <%- end -%>
 ```
 
-You can use the `#wrapped` method on any component inherited from `ApplicationViewComponent` to wrap it automatically:
+You can use the `#wrapped` method on any component inherited from `ApplicationViewComponent` to wrap it automatically.
+
+### Wrapping multiple components
+
+Sometimes a wrapper needs to wrap multiple components, and only render if at least one of the inner components renders.
+
+For example, consider a container element with a title and two components.
+
+```erb
+<div class="flex flex-col gap-4">
+  <h3>Title</h3>
+  <div class="flex gap-2">
+    <%= render ExampleA::Component %>
+    <%= render ExampleB::Component %>
+  </div>
+</div>
+```
+
+Both components have their own `#render?` method. If neither of the components render, then we don't want to render the container either.
+
+We introduce a special `ViewComponentContrib::ShowIfWrapperComponent` class that wraps around the container. We can declare the conditional parts of the markup with the `.show_if` block.
+
+```erb
+<%= render ViewComponentContrib::ShowIfWrapperComponent.new do |wrapper| %>
+  <div class="flex flex-col gap-4">
+    <h3>Title</h3>
+    <div class="flex gap-2">
+      <%= wrapper.show_if do %>
+        <%= render ExampleA::Component %>
+      <%- end ->
+      <%= wrapper.show_if do %>
+        <%= render ExampleB::Component %>
+      <%- end ->
+    </div>
+  </div>
+<%- end -%>
+```
+
+If _at least one_ of the `.show_if` blocks renders something, all of the content within the wrapper component is rendered. Otherwise, if nothing is rendered in _any_ of the blocks, the wrapper component doesn't render.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -830,7 +830,7 @@ We introduce a special `ViewComponentContrib::ShowIfWrapperComponent` class that
       <%- end ->
     </div>
   </div>
-<%- end -%>
+<%- end ->
 ```
 
 If nothing is rendered in _any_ of the blocks, the wrapper component doesn't render. Otherwise, if _at least one_ of the `.show_if` blocks renders something, all of the content within the wrapper component is rendered.

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ We introduce a special `ViewComponentContrib::ShowIfWrapperComponent` class that
 <%- end -%>
 ```
 
-If _at least one_ of the `.show_if` blocks renders something, all of the content within the wrapper component is rendered. Otherwise, if nothing is rendered in _any_ of the blocks, the wrapper component doesn't render.
+If nothing is rendered in _any_ of the blocks, the wrapper component doesn't render. Otherwise, if _at least one_ of the `.show_if` blocks renders something, all of the content within the wrapper component is rendered.
 
 ## License
 

--- a/lib/view_component_contrib.rb
+++ b/lib/view_component_contrib.rb
@@ -11,6 +11,7 @@ module ViewComponentContrib
   autoload :TranslationHelper, "view_component_contrib/translation_helper"
   autoload :WrapperComponent, "view_component_contrib/wrapper_component"
   autoload :WrappedHelper, "view_component_contrib/wrapped_helper"
+  autoload :ShowIfWrapperComponent, "view_component_contrib/show_if_wrapper_component"
   autoload :StyleVariants, "view_component_contrib/style_variants"
 
   autoload :Base, "view_component_contrib/base"

--- a/lib/view_component_contrib/show_if_wrapper_component.rb
+++ b/lib/view_component_contrib/show_if_wrapper_component.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ViewComponentContrib
+  class ShowIfWrapperComponent < ViewComponent::Base
+    # ShowIfWrapperComponent will only render if at least one of the
+    # conditional fragments produces output.
+    # A conditional fragment is declared by wrapping markup in a
+    # `show_if` block.
+
+    attr_reader :conditional_fragments
+
+    def before_render
+      @captured_content = content
+    end
+
+    def initialize
+      @conditional_fragments = []
+    end
+
+    def call
+      @captured_content if conditions_passed?
+    end
+
+    # Call this inside the template:  = w.show_if { … }
+    # Captures the block, pushes it into the list, and
+    # returns the HTML string so it appears inline where it was declared
+    def show_if(&block)
+      view_context.capture(&block).tap do |html|
+        conditional_fragments << html
+      end
+    end
+
+    # Render the wrapper itself only if:
+    #   - at least one conditional fragment produced output, OR
+    #   - no conditional fragments were declared
+    def conditions_passed?
+      conditional_fragments.empty? || conditional_fragments.any?(&:present?)
+    end
+  end
+end

--- a/test/cases/show_if_wrapper_component_test.rb
+++ b/test/cases/show_if_wrapper_component_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ShowIfWrapperComponentTest < ViewTestCase
+  class Component < ViewComponentContrib::Base
+    attr_reader :should_render
+
+    def initialize(should_render: true)
+      @should_render = should_render
+    end
+
+    alias_method :render?, :should_render
+
+    def call
+      "Hello from test".html_safe
+    end
+  end
+
+  def test_renders_when_two_inner_components_render
+    inner_component_a = Component.new
+    inner_component_b = Component.new
+    wrapper_component = ViewComponentContrib::ShowIfWrapperComponent.new
+
+    render_inline(wrapper_component) do |wrapper|
+      "<h3>Title</h3>" \
+      "<div>#{wrapper.show_if { render_inline(inner_component_a).to_html }}</div>" \
+      "<div>#{wrapper.show_if { render_inline(inner_component_b).to_html }}</div>".html_safe
+    end
+
+    assert_selector page, "h3", count: 1, text: "Title"
+    assert_selector page, "div", count: 2
+    assert_selector page, "div", text: "Hello from test", count: 2
+  end
+
+  def test_renders_when_one_inner_component_renders
+    inner_component_a = Component.new
+    inner_component_b = Component.new(should_render: false)
+    wrapper_component = ViewComponentContrib::ShowIfWrapperComponent.new
+
+    render_inline(wrapper_component) do |wrapper|
+      "<h3>Title</h3>" \
+      "<div>#{wrapper.show_if { render_inline(inner_component_a).to_html }}</div>" \
+      "<div>#{wrapper.show_if { render_inline(inner_component_b).to_html }}</div>".html_safe
+    end
+
+    assert_selector page, "h3", count: 1, text: "Title"
+    assert_selector page, "div", count: 2
+    assert_selector page, "div", text: "Hello from test", count: 1
+  end
+
+  def test_does_not_render_when_no_inner_components_render
+    inner_component_a = Component.new(should_render: false)
+    inner_component_b = Component.new(should_render: false)
+    wrapper_component = ViewComponentContrib::ShowIfWrapperComponent.new
+
+    render_inline(wrapper_component) do |wrapper|
+      "<h3>Title</h3>" \
+      "<div>#{wrapper.show_if { render_inline(inner_component_a).to_html }}</div>" \
+      "<div>#{wrapper.show_if { render_inline(inner_component_b).to_html }}</div>".html_safe
+    end
+
+    assert_no_selector page, "h3"
+    assert_no_selector page, "div"
+  end
+end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

Fixes #56.

## What changes did you make? (overview)

Adds a special component: `ShowIfWrapperComponent`.

This can be used to conditionally render content that is dependent on one of multiple components being rendered. 

For example, consider here that we only want the content to be rendered if either `ExampleA` or `ExampleB` is rendered.

```erb
<%= render ViewComponentContrib::ShowIfWrapperComponent.new do |wrapper| %>
  <div class="flex flex-col gap-4">
    <h3>Examples</h3>
    <div class="flex gap-2">
      <%= wrapper.show_if do %>
        <%= render ExampleA::Component %>
      <%- end ->
      <%= wrapper.show_if do %>
        <%= render ExampleB::Component %>
      <%- end ->
    </div>
  </div>
<%- end -%>
```

It also supports deep nesting of conditional wrappers.

Imagine we have a large section called "Examples", with two sub-sections: "Foo Examples" and "Bar Examples". Each sub-section should only render if it has at least one component rendered inside it, and the large section should only render if at least one sub-section is rendered. We can achieve the behaviour like this:

```erb
<%= render ViewComponentContrib::ShowIfWrapperComponent.new do |wrapper| %>
  <div class="flex flex-col gap-4">
    <h3>Examples</h3>

    <%= wrapper.show_if do %>
      <%= render ViewComponentContrib::ShowIfWrapperComponent.new do |foo_wrapper| %>
        <div class="flex flex-col gap-4">
          <h4>Foo Examples</h4>
          <div class="flex gap-2">
            <%= foo_wrapper.show_if do %>
              <%= render FooExampleA::Component %>
            <%- end ->
            <%= foo_wrapper.show_if do %>
              <%= render FooExampleB::Component %>
            <%- end ->
          </div>
        </div>
      <%- end ->
    <%- end ->

    <%= wrapper.show_if do %>
      <%= render ViewComponentContrib::ShowIfWrapperComponent.new do |bar_wrapper| %>
        <div class="flex flex-col gap-4">
          <h4>Bar Examples</h4>
          <div class="flex gap-2">
            <%= bar_wrapper.show_if do %>
              <%= render BarExampleA::Component %>
            <%- end ->
            <%= bar_wrapper.show_if do %>
              <%= render BarExampleB::Component %>
            <%- end ->
          </div>
        </div>
      <%- end ->
    <%- end ->
  </div>
<%- end ->
```

### How it works

Each `.show_if` block is captured as an HTML fragment before the wrapper component is rendered. Each fragment is checked, and if all are blank, the component is not rendered.

This has the added benefit of supporting _anything_ inside `show_if` blocks, not just components.

## Is there anything you'd like reviewers to focus on?

- Are there any preferred naming conventions to use? I'm not set on `ShowIfWrapperComponent`
- I've added a brand new component to avoid breaking changes, but there could be a way to extend `WrappedComponent` to achieve this functionality instead

Thanks 😄 

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
