### PR TITLE
Update for view_component v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix compatibility with view_component v4. 
+
 ## 0.2.4 (2025-01-03)
 
 - Add inheritance strategies to style variants ([@omarluq][])

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ config.autoload_paths << Rails.root.join("app", "frontend", "components")
 First, we need to specify the lookup path for previews in the app's configuration:
 
 ```ruby
-config.view_component.preview_paths << Rails.root.join("app", "frontend", "components")
+config.view_component.previews.paths << Rails.root.join("app", "frontend", "components")
 ```
 
 By default, ViewComponent requires preview files to have `_preview.rb` suffix, and it's not configurable (yet). To overcome this, we have to patch the `ViewComponent::Preview` class:

--- a/lib/view_component_contrib/railtie.rb
+++ b/lib/view_component_contrib/railtie.rb
@@ -2,11 +2,11 @@
 
 module ViewComponentContrib
   class Railtie < Rails::Railtie
-    config.view_component.preview_paths << File.join(ViewComponentContrib::APP_PATH, "views")
+    config.view_component.previews.paths << File.join(ViewComponentContrib::APP_PATH, "views")
 
     initializer "view_component-contrib.skip_loading_previews_if_disabled" do
-      unless Rails.application.config.view_component.show_previews
-        previews = Rails.application.config.view_component.preview_paths.flat_map do |path|
+      unless Rails.application.config.view_component.previews.enabled
+        previews = Rails.application.config.view_component.previews.paths.flat_map do |path|
           Pathname(path).glob("**/*preview.rb")
         end
         Rails.autoloaders.each { |autoloader| autoloader.ignore(previews) }

--- a/templates/install/template.rb
+++ b/templates/install/template.rb
@@ -12,7 +12,7 @@ ROOT_PATH = root.present? && root.downcase != "n" ? root : DEFAULT_ROOT
 
 root_paths = ROOT_PATH.split("/").map { |path| "\"#{path}\"" }.join(", ")
 
-application "config.view_component.preview_paths << Rails.root.join(#{root_paths})"
+application "config.view_component.previews.paths << Rails.root.join(#{root_paths})"
 application "config.autoload_paths << Rails.root.join(#{root_paths})"
 
 say_status :info, "✅ ViewComponent paths configured"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,11 +16,11 @@ Combustion.initialize! :action_controller, :action_view do
   config.logger = ActiveSupport::TaggedLogging.new(Logger.new(nil))
   config.log_level = :fatal
 
-  config.view_component.show_previews = true
+  config.view_component.previews.enabled = true
 
   config.autoload_paths << Rails.root.join("app", "frontend", "components")
-  config.view_component.preview_paths << Rails.root.join("app", "frontend", "components")
-  config.view_component.preview_paths << Rails.root.join("app", "frontend", "previews")
+  config.view_component.previews.paths << Rails.root.join("app", "frontend", "components")
+  config.view_component.previews.paths << Rails.root.join("app", "frontend", "previews")
 end
 
 class ApplicationController < ActionController::Base


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

View_component gem was updated to v4.0 but there is incompatible with the current gem due to some change on the configuration organization where this gem relies on.

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

I have changed the previous `config.view_components.preview_paths` from the v3.0 to the new `config.view_components.previews.paths`

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
