### PR TITLE
Add string support for style variants

### DIFF
--- a/lib/view_component_contrib/style_variants.rb
+++ b/lib/view_component_contrib/style_variants.rb
@@ -163,6 +163,7 @@ module ViewComponentContrib
         case val
         when true then :yes
         when false then :no
+        when String then val.to_sym
         else
           val
         end

--- a/test/cases/style_variants_test.rb
+++ b/test/cases/style_variants_test.rb
@@ -62,6 +62,14 @@ class StyledComponentTest < ViewTestCase
     assert_css "div.flex.flex-col.primary-color.primary-bg.text-sm"
   end
 
+  def test_render_string_value
+    component = Component.new(theme: "secondary", size: "md", disabled: true)
+
+    render_inline(component)
+
+    assert_css "div.secondary-color.secondary-bg.text-md.opacity-50"
+  end
+
   class SubComponent < Component
     erb_template <<~ERB
       <div class="<%= style(:component, theme: theme, size: size) %>">


### PR DESCRIPTION
### What is the purpose of this pull request?
Since variants always expected symbols, it was sometimes hard to debug why a component doesn't look as expected when passing strings.

### What changes did you make? (overview)
Allow passing strings as variant values by converting them to symbols.

### Example

**Before (didn't work):**
```ruby
style(size: 'sm') 
```

**After (works now):**
```ruby
style(size: 'sm')
style(size: :sm)
```